### PR TITLE
Updated alpine build to include ffprobe tool

### DIFF
--- a/Containerfile.d/Containerfile.alpine-static
+++ b/Containerfile.d/Containerfile.alpine-static
@@ -21,6 +21,7 @@ RUN wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.t
 FROM python:alpine
 ENV FFMPEG_VERSION=4.4.1
 COPY --from=prep ffmpeg-${FFMPEG_VERSION}-amd64-static/ffmpeg /usr/local/bin
+COPY --from=prep ffmpeg-${FFMPEG_VERSION}-amd64-static/ffprobe /usr/local/bin
 COPY ./yt-dlp.conf /etc/yt-dlp.conf
 
 COPY --from=prep yt-dlp /usr/local/bin


### PR DESCRIPTION
Currently the static ffmpeg binary package is downloaded but only the ffmpeg binary is copied over from the prep image into the builder. Any flags which require ffprobe then fails. This PR copies over the ffprobe too into the bin folder.